### PR TITLE
feat: allow to override Gradle tasks for gradle-service-publish

### DIFF
--- a/.github/workflows/gradle-service-publish.yml
+++ b/.github/workflows/gradle-service-publish.yml
@@ -1,6 +1,11 @@
 on:
   workflow_call:
     inputs:
+      gradle-tasks:
+        description: Custom Gradle tasks to run
+        required: false
+        type: string
+        default: ''
       java-version:
         description: Java version to use for build
         required: true
@@ -43,7 +48,7 @@ jobs:
   publish:
     uses: ./.github/workflows/gradle-service.yml
     with:
-      gradle-tasks: 'clean check dockerPushImage dockerPushLatest'
+      gradle-tasks: ${{ inputs.gradle-tasks != '' && inputs.gradle-tasks || 'clean check dockerPushImage dockerPushLatest' }}
       java-version: ${{ inputs.java-version }}
       image-tag: ${{ inputs.image-tag }}
       image-tag-2: ${{ inputs.image-tag-2 }}


### PR DESCRIPTION
This allows for the [use case in hale-cli](https://github.com/halestudio/hale-cli/blob/b1559b1cd0e7d731c8bdbad2af9204558439d224/.github/workflows/publish.yml#L34) where `gradle-tasks` is provided to skip the tests for the `docker' job.