### PR TITLE
fix: specify and pass on secrets explicitly

### DIFF
--- a/.github/workflows/dockerfile-build.yml
+++ b/.github/workflows/dockerfile-build.yml
@@ -31,4 +31,9 @@ jobs:
       checkout-ref: ${{ inputs.checkout-ref }}
       push: false
       notify-failure: false
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/dockerfile-publish.yml
+++ b/.github/workflows/dockerfile-publish.yml
@@ -35,4 +35,10 @@ jobs:
       checkout-ref: ${{ inputs.checkout-ref }}
       push: true
       notify-failure: true
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}

--- a/.github/workflows/gradle-library-check.yml
+++ b/.github/workflows/gradle-library-check.yml
@@ -42,6 +42,11 @@ on:
       WETF_ARTIFACTORY_USER:
       WETF_ARTIFACTORY_PASSWORD:
 
+      GH_PAT:
+      DOCKER_HUB_USERNAME:
+      DOCKER_HUB_PASSWORD:
+      DOCKER_HUB_EMAIL:
+
 jobs:
   check:
     uses: ./.github/workflows/gradle-library.yml
@@ -56,4 +61,13 @@ jobs:
       upload-artifact-path: ${{ inputs.upload-artifact-path }}
       upload-artifact-name: ${{ inputs.upload-artifact-name }}
       notify-failure: false
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+      GH_PAT: ${{ secrets.GH_PAT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      DOCKER_HUB_EMAIL: ${{ secrets.DOCKER_HUB_EMAIL }}

--- a/.github/workflows/gradle-library-publish.yml
+++ b/.github/workflows/gradle-library-publish.yml
@@ -65,6 +65,11 @@ on:
       WE_RELEASE_GITHUB_APP_ID:
       WE_RELEASE_GITHUB_PRIVATE_KEY:
 
+      GH_PAT:
+      DOCKER_HUB_USERNAME:
+      DOCKER_HUB_PASSWORD:
+      DOCKER_HUB_EMAIL:
+
 jobs:
   publish:
     uses: ./.github/workflows/gradle-library.yml
@@ -81,4 +86,16 @@ jobs:
       upload-artifact-name: ${{ inputs.upload-artifact-name }}
       semantic-release: ${{ inputs.semantic-release }}
       semantic-release-dryrun: ${{ inputs.semantic-release-dryrun }}
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+      SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+      WE_RELEASE_GITHUB_APP_ID: ${{ secrets.WE_RELEASE_GITHUB_APP_ID }}
+      WE_RELEASE_GITHUB_PRIVATE_KEY: ${{ secrets.WE_RELEASE_GITHUB_PRIVATE_KEY }}
+      GH_PAT: ${{ secrets.GH_PAT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      DOCKER_HUB_EMAIL: ${{ secrets.DOCKER_HUB_EMAIL }}

--- a/.github/workflows/gradle-library.yml
+++ b/.github/workflows/gradle-library.yml
@@ -78,7 +78,7 @@ on:
         description: The release version if a release was created
         value: ${{ jobs.run.outputs.release-version }}
     secrets:
-      # GH_PAT:
+      GH_PAT:
       #   required: true
       WETF_ARTIFACTORY_USER:
       WETF_ARTIFACTORY_PASSWORD:

--- a/.github/workflows/gradle-service-check.yml
+++ b/.github/workflows/gradle-service-check.yml
@@ -39,8 +39,7 @@ on:
         type: string
         default: ''
     secrets:
-      # GH_PAT:
-      #   required: true
+      GH_PAT:
       DOCKER_HUB_USERNAME:
       DOCKER_HUB_PASSWORD:
       DOCKER_HUB_EMAIL:
@@ -62,4 +61,14 @@ jobs:
       submodules: ${{ inputs.submodules }}
       checkout-ref: ${{ inputs.checkout-ref }}
       notify-failure: false
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      DOCKER_HUB_EMAIL: ${{ secrets.DOCKER_HUB_EMAIL }}
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+      ENV_VARS: ${{ secrets.ENV_VARS }}

--- a/.github/workflows/gradle-service-publish.yml
+++ b/.github/workflows/gradle-service-publish.yml
@@ -52,8 +52,7 @@ on:
         default: false
         type: boolean
     secrets:
-      # GH_PAT:
-      #   required: true
+      GH_PAT:
       DOCKER_HUB_USERNAME:
         required: true
       DOCKER_HUB_PASSWORD:
@@ -84,4 +83,17 @@ jobs:
       semantic-release: ${{ inputs.semantic-release }}
       semantic-release-dryrun: ${{ inputs.semantic-release-dryrun }}
       skip-scan: ${{ inputs.semantic-release-dryrun && inputs.semantic-release }} # dryrun does not produce image, so skip scan
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      DOCKER_HUB_EMAIL: ${{ secrets.DOCKER_HUB_EMAIL }}
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+      SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+      WE_RELEASE_GITHUB_APP_ID: ${{ secrets.WE_RELEASE_GITHUB_APP_ID }}
+      WE_RELEASE_GITHUB_PRIVATE_KEY: ${{ secrets.WE_RELEASE_GITHUB_PRIVATE_KEY }}
+      ENV_VARS: ${{ secrets.ENV_VARS }}

--- a/.github/workflows/gradle-service.yml
+++ b/.github/workflows/gradle-service.yml
@@ -74,7 +74,7 @@ on:
         description: The release version if a release was created
         value: ${{ jobs.run.outputs.release-version }}
     secrets:
-      # GH_PAT:
+      GH_PAT:
       #   required: true
       DOCKER_HUB_USERNAME:
       DOCKER_HUB_PASSWORD:

--- a/.github/workflows/play-service-check.yml
+++ b/.github/workflows/play-service-check.yml
@@ -35,4 +35,12 @@ jobs:
       image-tag: ${{ inputs.image-tag }}
       notify-failure: false
       push-image: false
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      DOCKER_HUB_EMAIL: ${{ secrets.DOCKER_HUB_EMAIL }}
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/play-service-publish.yml
+++ b/.github/workflows/play-service-publish.yml
@@ -38,4 +38,13 @@ jobs:
       image-tag: ${{ inputs.image-tag }}
       notify-failure: true
       push-image: true
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      DOCKER_HUB_EMAIL: ${{ secrets.DOCKER_HUB_EMAIL }}
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+      SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}

--- a/.github/workflows/sbt-library-check.yml
+++ b/.github/workflows/sbt-library-check.yml
@@ -31,4 +31,9 @@ jobs:
       java-version: ${{ inputs.java-version }}
       expect-tests: ${{ inputs.expect-tests }}
       notify-failure: false
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/sbt-library-publish.yml
+++ b/.github/workflows/sbt-library-publish.yml
@@ -35,4 +35,10 @@ jobs:
       java-version: ${{ inputs.java-version }}
       expect-tests: ${{ inputs.expect-tests }}
       notify-failure: true
-    secrets: inherit
+    # secrets: inherit
+    # passing on secrets via inherit seems to be no longer possible
+    # if this workflow is included from a foreign organisation
+    secrets:
+      WETF_ARTIFACTORY_USER: ${{ secrets.WETF_ARTIFACTORY_USER }}
+      WETF_ARTIFACTORY_PASSWORD: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}
+      SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}


### PR DESCRIPTION
It seems the behavior in GitHub Actions has changed. Previously it was possible to reuse a workflow from another organization which could in turn reuse workflow from that same organization while inheriting secrets using `secrets: inherit`.
This currently is no longer possible. Secrets have to be specified explicitly for both kinds of reuses where before it was only necessary for the workflow that was explicitly referenced from another organization.