### PR TITLE
feat(gradle): allow skipping build check for publish/release

### DIFF
--- a/.github/workflows/gradle-library-publish.yml
+++ b/.github/workflows/gradle-library-publish.yml
@@ -23,6 +23,10 @@ on:
         description: If JUnit test results are expected
         default: true
         type: boolean
+      skip-check:
+        description: Skip build/verification and only publish
+        default: false
+        type: boolean
       submodules:
         # see https://github.com/actions/checkout
         default: 'false'
@@ -79,6 +83,7 @@ jobs:
       java-version: ${{ inputs.java-version }}
       multi-module: ${{ inputs.multi-module }}
       expect-tests: ${{ inputs.expect-tests }}
+      skip-build: ${{ inputs.skip-check }}
       submodules: ${{ inputs.submodules }}
       checkout-ref: ${{ inputs.checkout-ref }}
       skip-scan: ${{ inputs.skip-scan }}

--- a/.github/workflows/gradle-library.yml
+++ b/.github/workflows/gradle-library.yml
@@ -27,7 +27,7 @@ on:
         default: true
         type: boolean
       skip-build:
-        description: Skip build/publishing and only scan vulnerabilities
+        description: Skip build and only publish and scan vulnerabilities
         default: false
         type: boolean
       expect-tests:
@@ -212,7 +212,7 @@ jobs:
       #
 
       - name: Determine app token for release
-        if: ${{ !inputs.skip-build && inputs.publish-tasks != '' && inputs.semantic-release }}
+        if: ${{ inputs.publish-tasks != '' && inputs.semantic-release }}
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         id: app-token
         with:
@@ -221,7 +221,7 @@ jobs:
 
       - name: Publish/release with Gradle
         id: gradle-release
-        if: ${{ !inputs.skip-build && inputs.publish-tasks != '' }}
+        if: ${{ inputs.publish-tasks != '' }}
         uses: wetransform/gha-gradle-semantic-release@065a33533593c9987f59336749538bc8a8626828 # v2.1.1
         with:
           publish-tasks: ${{ inputs.publish-tasks }}

--- a/.github/workflows/gradle-service-publish.yml
+++ b/.github/workflows/gradle-service-publish.yml
@@ -35,6 +35,10 @@ on:
         description: If JUnit test results are expected
         default: true
         type: boolean
+      skip-check:
+        description: Skip build/verification and only publish
+        default: false
+        type: boolean
       submodules:
         # see https://github.com/actions/checkout
         default: 'false'
@@ -78,6 +82,7 @@ jobs:
       image-tag-3: ${{ inputs.image-tag-3 }}
       multi-module: ${{ inputs.multi-module }}
       expect-tests: ${{ inputs.expect-tests }}
+      skip-build: ${{ inputs.skip-check }}
       submodules: ${{ inputs.submodules }}
       checkout-ref: ${{ inputs.checkout-ref }}
       semantic-release: ${{ inputs.semantic-release }}

--- a/.github/workflows/gradle-service.yml
+++ b/.github/workflows/gradle-service.yml
@@ -31,7 +31,7 @@ on:
         default: true
         type: boolean
       skip-build:
-        description: Skip build/publishing and only scan vulnerabilities
+        description: Skip build (checks) and only publish and scan vulnerabilities
         default: false
         type: boolean
       submodules:
@@ -182,7 +182,7 @@ jobs:
       #
 
       - name: Determine app token for release
-        if: ${{ !inputs.skip-build && inputs.publish-tasks != '' && inputs.semantic-release }}
+        if: ${{ inputs.publish-tasks != '' && inputs.semantic-release }}
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         id: app-token
         with:
@@ -191,7 +191,7 @@ jobs:
 
       - name: Publish/release with Gradle
         id: gradle-release
-        if: ${{ !inputs.skip-build && inputs.publish-tasks != '' }}
+        if: ${{ inputs.publish-tasks != '' }}
         uses: wetransform/gha-gradle-semantic-release@065a33533593c9987f59336749538bc8a8626828 # v2.1.1
         with:
           publish-tasks: ${{ inputs.publish-tasks }}


### PR DESCRIPTION
BREAKING CHANGE: Behavior of skip-build parameter for gradle-library.yml and gradle-service.yml workflows changed.