### PR TITLE
ci: scan for secrets on external PRs without slack notification

### DIFF
--- a/.github/workflows/scan-for-secrets.yml
+++ b/.github/workflows/scan-for-secrets.yml
@@ -4,9 +4,7 @@ on:
   workflow_call:
     secrets:
       SLACK_EXPOSED_SECRETS_WEBHOOK:
-        required: true
-#  push:
-#    branches: ["**"]
+        required: false
 
 env:
   REPORT_FILE: gitleaks-report.json
@@ -17,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       report-url: ${{ steps.upload-report.outputs.artifact-url }}
+      slack-webhook-set: ${{ steps.check-slack.outputs.is-set }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -63,6 +62,17 @@ jobs:
           path: "${{ env.REPORT_FILE }}"
           retention-days: 30
 
+      - name: Check if Slack webhook is configured
+        id: check-slack
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_EXPOSED_SECRETS_WEBHOOK }}
+        run: |
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            echo "is-set=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-set=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Fail if secrets were detected
         if: steps.gitleaks.outputs.exitcode != '0'
         run: |
@@ -71,7 +81,7 @@ jobs:
 
   slack-notify:
     name: Notify on Slack if secrets were detected
-    if: failure()
+    if: failure() && needs.secret-scan.outputs.slack-webhook-set == 'true'
     runs-on: ubuntu-latest
     needs: secret-scan
     steps:


### PR DESCRIPTION
this way no secrets are required for the workflow run, so it can automatically run on external PRs.

Unfortunately, I could only test this logic locally with `act`, as in the repo's it would wait for status to be reported. (I suppose due to changes on the workflow non-admin commiters.)
However, locally it worked fine.

ING-5175