### PR TITLE
fix: skip hk git hooks when semantic-release commits and pushes

### DIFF
--- a/.github/workflows/gradle-library.yml
+++ b/.github/workflows/gradle-library.yml
@@ -245,6 +245,17 @@ jobs:
           release-dryrun: ${{ inputs.semantic-release-dryrun }}
           github-token: ${{ steps.app-token.outputs.token }}
         env:
+          # Skip hk-managed git hooks (installed by the mise postinstall hook via mise-action)
+          # for the release commit/push - hk's stash requires git config user.name, which is
+          # not configured in CI (semantic-release provides the identity via GIT_* env vars,
+          # which libgit2-based hk does not evaluate)
+          # HK=0 is hk's documented shim-level escape hatch (see hk docs, "getting started"):
+          # it takes effect in the installed hook script itself, before mise resolves tools or
+          # hk evaluates its config - unlike HK_SKIP_HOOK, which requires hk to start and
+          # evaluate hk.pkl (incl. remote imports) first and would keep releases coupled to
+          # hk/hk-config health
+          HK: "0"
+
           # For Gradle execution
           ORG_GRADLE_PROJECT_wetfArtifactoryUser: ${{ secrets.WETF_ARTIFACTORY_USER }}
           ORG_GRADLE_PROJECT_wetfArtifactoryPassword: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/gradle-service.yml
+++ b/.github/workflows/gradle-service.yml
@@ -217,6 +217,17 @@ jobs:
           release-dryrun: ${{ inputs.semantic-release-dryrun }}
           github-token: ${{ steps.app-token.outputs.token }}
         env:
+          # Skip hk-managed git hooks (installed by the mise postinstall hook via mise-action)
+          # for the release commit/push - hk's stash requires git config user.name, which is
+          # not configured in CI (semantic-release provides the identity via GIT_* env vars,
+          # which libgit2-based hk does not evaluate)
+          # HK=0 is hk's documented shim-level escape hatch (see hk docs, "getting started"):
+          # it takes effect in the installed hook script itself, before mise resolves tools or
+          # hk evaluates its config - unlike HK_SKIP_HOOK, which requires hk to start and
+          # evaluate hk.pkl (incl. remote imports) first and would keep releases coupled to
+          # hk/hk-config health
+          HK: "0"
+
           # For Gradle execution
           ORG_GRADLE_PROJECT_wetfArtifactoryUser: ${{ secrets.WETF_ARTIFACTORY_USER }}
           ORG_GRADLE_PROJECT_wetfArtifactoryPassword: ${{ secrets.WETF_ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/mise-release.yml
+++ b/.github/workflows/mise-release.yml
@@ -170,6 +170,16 @@ jobs:
           RUNNER_DEBUG: 1
 
           MISE_ENV: ci
+
+          # Skip hk-managed git hooks (installed by the mise postinstall hook via mise-action)
+          # for the release commit/push - hk's stash requires git config user.name, which is
+          # not configured in CI (the GIT_* env vars above are not evaluated by libgit2-based hk)
+          # HK=0 is hk's documented shim-level escape hatch (see hk docs, "getting started"):
+          # it takes effect in the installed hook script itself, before mise resolves tools or
+          # hk evaluates its config - unlike HK_SKIP_HOOK, which requires hk to start and
+          # evaluate hk.pkl (incl. remote imports) first and would keep releases coupled to
+          # hk/hk-config health
+          HK: "0"
         with:
           dry_run: ${{ inputs.dry-run }}
           semantic_version: 25.0.3

--- a/mise.toml
+++ b/mise.toml
@@ -3,6 +3,12 @@
 hk = "latest"
 pkl = "latest"
 
+[env]
+# Evaluate hk.pkl with the official pkl CLI instead of hk's embedded pklr evaluator,
+# which fails on constructs used by wetransform/hk-config (e.g. "field not found:
+# disable_pre_commit" with hk >= 1.49)
+HK_PKL_BACKEND = "pkl"
+
 [hooks]
 enter = "mise x -- hk install --mise"
 postinstall = "mise x -- hk install --mise"


### PR DESCRIPTION
## Problem

Release workflows in consumer repos with a `mise.toml` (e.g. [bucket-service run 28852149529](https://github.com/wetransform/bucket-service/actions/runs/28852149529)) fail at the `@semantic-release/git` prepare step:

```
stash – Running git stash (1 file)
Error: config value 'user.name' was not found; class=Config (7); code=NotFound (-3)
Location: src/git.rs:806:23
```

Cause chain:
1. `jdx/mise-action` runs `mise install`, which triggers the mise `postinstall` hook `hk install --mise` — installing the hk git hooks **in the CI runner**.
2. `@semantic-release/git` runs `git commit` (without `--no-verify`), so the hk pre-commit hook fires.
3. hk (`stash = "git"`) stashes unstaged files via libgit2, which requires `git config user.name`. That is never configured in CI — semantic-release provides the identity only via `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env vars, which the git CLI evaluates but libgit2 does not.

## Fix

Set `HK: "0"` on the steps that run semantic-release (`gradle-service.yml`, `gradle-library.yml`, `mise-release.yml`). The hk-installed hook script (`test "${HK:-1}" = "0" || exec mise x -- hk run pre-commit`) then skips itself for the release commit and the tag push. The actual checks are unaffected — they run via the regular check workflows (`hk check`), not via git hooks.

`tf-release.yml` is not touched: it is a managed workflow and does not use mise-action, so no hooks are installed there.

## Considered alternatives

**`HK_STASH: none` on the release step** — hk honors the `HK_STASH` env var, which overrides the hook's stash method (hk 1.46.0 `src/env.rs:48-53`; the env var takes precedence in `resolve_stash_method`). This would skip only the stash (and thus the crash) while still running the hook steps. Rejected because:

- The hook run provides no protection on a release commit: the only staged file is the generated `CHANGELOG.md`, which hk-config's prettier step explicitly excludes as generated/managed. All it adds is cost — the spotless step boots Gradle on every release (~1 min).
- It keeps releases coupled to hk/hk-config health. Any hk breakage unrelated to the release would still fail every release — e.g. the current incompatibility of unpinned hk `latest` with hk-config v2.3.0 (`Eval error: field not found: ...`, see the failing `check-hooks` check on this PR) would break all releases. With `HK: "0"` releases are immune to that entire failure class.

**`disable_pre_commit` in hk-config** — does not work: the crash happens in the hook-level stash phase, not in a step. In `Hook::run()` (hk 1.46.0 `src/hook.rs`), the early exit only triggers when *no* files are staged; the stash block (`hook.rs:894`) runs before the `groups.is_empty()` ("no steps to run") check. Since the release commit always stages `CHANGELOG.md`, hk would stash — and crash — even with every step disabled. It would also be *more* invasive, as it applies everywhere including local developer commits.

## Also in this PR: fix hk config evaluation (pklr → pkl CLI)

The failing `check-hooks` check on this PR (and on all recent PRs in this repo) is a separate, pre-existing problem: hk's embedded **pklr** evaluator fails to evaluate `wetransform/hk-config` — older versions with `Import not found` on relative imports, hk ≥ 1.49 with `field not found: disable_pre_commit`. The second commit sets `HK_PKL_BACKEND=pkl` in `mise.toml` so hk evaluates `hk.pkl` with the official pkl CLI (already installed via mise), locally and in CI. Verified locally with hk 1.50.0: config evaluation panics with pklr and succeeds with the pkl CLI.

## Verification

- `hk check` passes locally (prettier, actionlint, yaml-schema, gitleaks).
- End-to-end: after release, bump the `gha-workflows` pin in bucket-service and re-run its Release workflow — the previously failing `git commit -m "chore(release): 2.2.0 [skip ci]"` must succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
