### PR TITLE
fix(mise-release): pin conventional-changelog-conventionalcommits to 9.x

### DIFF
--- a/.github/workflows/mise-release.yml
+++ b/.github/workflows/mise-release.yml
@@ -41,7 +41,12 @@ env:
   SEMANTIC_RELEASE_GIT_VERSION: 10.0.1
 
   # renovate: datasource=npm depName=conventional-changelog-conventionalcommits
-  CONVENTIONAL_CHANGELOG_CONVENTIONALCOMMITS_VERSION: 10.2.1
+  # Held at 9.x: v10 targets conventional-changelog-writer v9, but semantic-release 25.x
+  # (commit-analyzer 13 / release-notes-generator 14) render with writer v8, so v10 produces
+  # empty release notes (only the version header). Renovate is constrained to <10 in the
+  # shared renovate-config. Lift once the semantic-release ecosystem supports v10:
+  # https://github.com/semantic-release/release-notes-generator/issues/992
+  CONVENTIONAL_CHANGELOG_CONVENTIONALCOMMITS_VERSION: 9.3.1
 
 jobs:
   release:


### PR DESCRIPTION
v10 targets conventional-changelog-writer v9, but semantic-release 25.x renders release notes with writer v8, so v10 emits only the version header with no commit sections (empty changelog / GitHub release body). Revert the Renovate v10 bump (961fa4f) back to 9.3.1. Renovate is constrained to <10 in the shared renovate-config. Upstream: semantic-release/release-notes-generator#992.