### PR TITLE
feat(dockerfile): support submodules configuration

### DIFF
--- a/.github/workflows/dockerfile-build.yml
+++ b/.github/workflows/dockerfile-build.yml
@@ -17,9 +17,14 @@ on:
         description: Custom ref to check out
         type: string
         default: ""
+      submodules:
+        # see https://github.com/actions/checkout
+        default: "false"
+        type: string
     secrets:
       DOCKER_HUB_USERNAME:
       DOCKER_HUB_PASSWORD:
+      GH_PAT:
 
 jobs:
   build:
@@ -29,6 +34,7 @@ jobs:
       tag: ${{ inputs.tag }}
       context: ${{ inputs.context }}
       checkout-ref: ${{ inputs.checkout-ref }}
+      submodules: ${{ inputs.submodules }}
       push: false
       notify-failure: false
     # secrets: inherit
@@ -37,3 +43,4 @@ jobs:
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/dockerfile-publish.yml
+++ b/.github/workflows/dockerfile-publish.yml
@@ -17,11 +17,16 @@ on:
         description: Custom ref to check out
         type: string
         default: ""
+      submodules:
+        # see https://github.com/actions/checkout
+        default: "false"
+        type: string
     secrets:
       DOCKER_HUB_USERNAME:
         required: true
       DOCKER_HUB_PASSWORD:
         required: true
+      GH_PAT:
       SLACK_NOTIFICATIONS_BOT_TOKEN:
         required: true
 
@@ -33,6 +38,7 @@ jobs:
       tag: ${{ inputs.tag }}
       context: ${{ inputs.context }}
       checkout-ref: ${{ inputs.checkout-ref }}
+      submodules: ${{ inputs.submodules }}
       push: true
       notify-failure: true
     # secrets: inherit
@@ -41,4 +47,5 @@ jobs:
     secrets:
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      GH_PAT: ${{ secrets.GH_PAT }}
       SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}

--- a/.github/workflows/dockerfile.yml
+++ b/.github/workflows/dockerfile.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref }}
           submodules: ${{ inputs.submodules }}
-          # do not persist credentials so a submodule PAT does not end up in
+          # so no checkout credential (PAT or GITHUB_TOKEN) ends up in
           # .git/config inside the Docker build context
           persist-credentials: false
           # provide a token in case submodules are enabled and private (secret is expected to be present)

--- a/.github/workflows/dockerfile.yml
+++ b/.github/workflows/dockerfile.yml
@@ -25,9 +25,14 @@ on:
         description: Custom ref to check out
         type: string
         default: ""
+      submodules:
+        # see https://github.com/actions/checkout
+        default: "false"
+        type: string
     secrets:
       DOCKER_HUB_USERNAME:
       DOCKER_HUB_PASSWORD:
+      GH_PAT:
       SLACK_NOTIFICATIONS_BOT_TOKEN:
 
 jobs:
@@ -37,6 +42,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout-ref }}
+          submodules: ${{ inputs.submodules }}
+          # do not persist credentials so a submodule PAT does not end up in
+          # .git/config inside the Docker build context
+          persist-credentials: false
+          # provide a token in case submodules are enabled and private (secret is expected to be present)
+          token: ${{ inputs.submodules != 'false' && secrets.GH_PAT || github.token }}
 
       - name: Docker meta
         id: meta

--- a/docs/superpowers/plans/2026-08-13-dockerfile-workflow-submodules.md
+++ b/docs/superpowers/plans/2026-08-13-dockerfile-workflow-submodules.md
@@ -1,0 +1,338 @@
+# Dockerfile Workflow Submodules Support — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let callers of the Dockerfile reusable workflows check out git submodules, including private ones, by adding a `submodules` input and an optional `GH_PAT` secret.
+
+**Architecture:** Copy the pattern already used by `gradle-library.yml`, `gradle-service.yml` and `mise.yml` verbatim: a string `submodules` input forwarded to `actions/checkout`, plus a conditional `token:` expression that swaps in `GH_PAT` only when submodules are enabled. The two wrapper workflows declare the same input and secret and pass them straight through. One extra hardening line, `persist-credentials: false`, keeps the PAT out of the Docker build context.
+
+**Tech Stack:** GitHub Actions reusable workflows (YAML), `actions/checkout` v7, validated by `actionlint` 1.7.12 and Prettier 3.9.6, both run via the repo's `hk` pre-commit hook.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-dockerfile-workflow-submodules-design.md`
+
+## Global Constraints
+
+- The `submodules` input is **type `string`**, default the quoted string `"false"` — not a boolean. The `!= 'false'` comparison in the token expression depends on this.
+- `GH_PAT` is **always optional** — never add `required: true` to it, in any of the three files. `dockerfile-publish.yml` marks its other secrets required; `GH_PAT` must not follow suit.
+- Do **not** change the pinned `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` SHA or any other action pin.
+- Comment lines are copied verbatim from the snippets below, including the `# see https://github.com/actions/checkout` line above the input.
+- The `submodules` input goes immediately after `checkout-ref` in all three files. `GH_PAT` goes immediately after `DOCKER_HUB_PASSWORD` in all three files.
+- Conventional commits are enforced (semantic-release). This change ships as a single `feat:` commit.
+- Out of scope: `play-service.*`, `sbt-library.*`, `mise-release.yml`, `scan-for-secrets.yml`, and the managed `tf-*` workflows. Do not touch them.
+
+**Reading the YAML snippets below:** every snippet is rooted at the top level of the file (`on:` or `jobs:`) and shows surrounding context, so the indentation you see is the indentation to write. Lines marked `# ... unchanged` stand for existing content you leave alone — do not delete it, and do not paste that comment into the file.
+
+---
+
+## File Structure
+
+Three files, all under `.github/workflows/`. No new files.
+
+| File                     | Responsibility                                                                 | Change                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `dockerfile.yml`         | The reusable workflow that actually performs the checkout and the Docker build | Declare `submodules` input + `GH_PAT` secret; wire both into the checkout step; add `persist-credentials: false` |
+| `dockerfile-build.yml`   | Thin wrapper — builds without pushing                                          | Declare `submodules` + `GH_PAT`; forward both                                                                    |
+| `dockerfile-publish.yml` | Thin wrapper — builds and pushes                                               | Declare `submodules` + `GH_PAT`; forward both                                                                    |
+
+The wrappers are near-identical; the only differences are `push`/`notify-failure` values and that `dockerfile-publish.yml` also handles `SLACK_NOTIFICATIONS_BOT_TOKEN` and marks its secrets required.
+
+---
+
+## How this is tested
+
+This repo has **no unit-test harness for workflows**. The real test is `actionlint`, which validates calls to local reusable workflows: if a wrapper passes an input or secret that `dockerfile.yml` does not declare, actionlint fails with a specific error. That gives a genuine red/green cycle — edit the wrappers first (the "test"), watch actionlint fail, then implement `dockerfile.yml` and watch it pass.
+
+Both tools are already configured in `hk.pkl` via `wetransform/hk-config`. actionlint's glob covers `.github/workflows/*.yml` and excludes only `tf-*`, so all three files are checked.
+
+The exact commands and their expected output below were verified against a scratch copy of these three workflows before this plan was written. The output is real, not illustrative.
+
+---
+
+## Task 1: Add submodules support to the Dockerfile workflows
+
+**Files:**
+
+- Modify: `.github/workflows/dockerfile-build.yml` — inputs block, `with:` block, `secrets:` blocks
+- Modify: `.github/workflows/dockerfile-publish.yml` — inputs block, `with:` block, `secrets:` blocks
+- Modify: `.github/workflows/dockerfile.yml` — inputs block, `secrets:` block, checkout step
+- Test: none — validated by `actionlint`, see "How this is tested" above
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks (this is the only task).
+- Produces: `dockerfile.yml` gains input `submodules` (string, default `"false"`) and optional secret `GH_PAT`. Both wrappers expose the identical input and secret names to their own callers.
+
+---
+
+- [ ] **Step 1: Confirm the starting point is green**
+
+Run:
+
+```bash
+mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint
+```
+
+Expected: exit 0, no output. If there are pre-existing errors in unrelated workflows, note them — they are not yours to fix, but you need to know them so you can tell them apart from the errors Step 3 expects.
+
+---
+
+- [ ] **Step 2: Write the failing test — declare and forward in `dockerfile-build.yml`**
+
+Edit `.github/workflows/dockerfile-build.yml`. Declare the input and the secret:
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      # ... image, tag, context unchanged
+      checkout-ref:
+        description: Custom ref to check out
+        type: string
+        default: ""
+      submodules:
+        # see https://github.com/actions/checkout
+        default: "false"
+        type: string
+    secrets:
+      DOCKER_HUB_USERNAME:
+      DOCKER_HUB_PASSWORD:
+      GH_PAT:
+```
+
+Then forward both to the called workflow:
+
+```yaml
+jobs:
+  build:
+    uses: ./.github/workflows/dockerfile.yml
+    with:
+      # ... image, tag, context unchanged
+      checkout-ref: ${{ inputs.checkout-ref }}
+      submodules: ${{ inputs.submodules }}
+      push: false
+      notify-failure: false
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      GH_PAT: ${{ secrets.GH_PAT }}
+```
+
+Leave the existing `# secrets: inherit` comment block above `secrets:` in place.
+
+---
+
+- [ ] **Step 3: Write the failing test — declare and forward in `dockerfile-publish.yml`**
+
+Edit `.github/workflows/dockerfile-publish.yml`. This file marks its secrets `required: true`; `GH_PAT` does **not** get that, and it sits between `DOCKER_HUB_PASSWORD` and `SLACK_NOTIFICATIONS_BOT_TOKEN`:
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      # ... image, tag, context unchanged
+      checkout-ref:
+        description: Custom ref to check out
+        type: string
+        default: ""
+      submodules:
+        # see https://github.com/actions/checkout
+        default: "false"
+        type: string
+    secrets:
+      DOCKER_HUB_USERNAME:
+        required: true
+      DOCKER_HUB_PASSWORD:
+        required: true
+      GH_PAT:
+      SLACK_NOTIFICATIONS_BOT_TOKEN:
+        required: true
+```
+
+Then forward both:
+
+```yaml
+jobs:
+  publish:
+    uses: ./.github/workflows/dockerfile.yml
+    with:
+      # ... image, tag, context unchanged
+      checkout-ref: ${{ inputs.checkout-ref }}
+      submodules: ${{ inputs.submodules }}
+      push: true
+      notify-failure: true
+    secrets:
+      DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      GH_PAT: ${{ secrets.GH_PAT }}
+      SLACK_NOTIFICATIONS_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+```
+
+---
+
+- [ ] **Step 4: Run actionlint to verify it fails**
+
+Run:
+
+```bash
+mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint
+```
+
+Expected: exit 1, with exactly these four errors (line numbers may shift by a line or two):
+
+```
+.github/workflows/dockerfile-build.yml:37:7: input "submodules" is not defined in "./.github/workflows/dockerfile.yml" reusable workflow. defined inputs are "checkout-ref", "context", "image", "notify-failure", "push", "tag" [workflow-call]
+.github/workflows/dockerfile-build.yml:46:7: secret "GH_PAT" is not defined in "./.github/workflows/dockerfile.yml" reusable workflow. defined secrets are "DOCKER_HUB_PASSWORD", "DOCKER_HUB_USERNAME", "SLACK_NOTIFICATIONS_BOT_TOKEN" [workflow-call]
+.github/workflows/dockerfile-publish.yml:41:7: input "submodules" is not defined in "./.github/workflows/dockerfile.yml" reusable workflow. defined inputs are "checkout-ref", "context", "image", "notify-failure", "push", "tag" [workflow-call]
+.github/workflows/dockerfile-publish.yml:50:7: secret "GH_PAT" is not defined in "./.github/workflows/dockerfile.yml" reusable workflow. defined secrets are "DOCKER_HUB_PASSWORD", "DOCKER_HUB_USERNAME", "SLACK_NOTIFICATIONS_BOT_TOKEN" [workflow-call]
+```
+
+This is the red phase, and it is the reason for editing the wrappers first — it proves the wrappers really are wired to `dockerfile.yml` and that actionlint is watching.
+
+If you instead see errors of the form `property "submodules" is not defined in object type {...}` or `property "gh_pat" is not defined in object type {...}`, you added the pass-through in the `with:`/`secrets:` block but forgot to **declare** the input or secret in that same wrapper's own `on.workflow_call` block. Go back and add the declaration.
+
+---
+
+- [ ] **Step 5: Implement — declare the input and secret in `dockerfile.yml`**
+
+Edit `.github/workflows/dockerfile.yml`. Add `submodules` after `checkout-ref`, and `GH_PAT` between `DOCKER_HUB_PASSWORD` and `SLACK_NOTIFICATIONS_BOT_TOKEN` — the same ordering `mise.yml` uses:
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      # ... notify-failure, image, tag, push, context unchanged
+      checkout-ref:
+        description: Custom ref to check out
+        type: string
+        default: ""
+      submodules:
+        # see https://github.com/actions/checkout
+        default: "false"
+        type: string
+    secrets:
+      DOCKER_HUB_USERNAME:
+      DOCKER_HUB_PASSWORD:
+      GH_PAT:
+      SLACK_NOTIFICATIONS_BOT_TOKEN:
+```
+
+---
+
+- [ ] **Step 6: Implement — wire the checkout step in `dockerfile.yml`**
+
+The checkout step is the first step of the `run` job and currently has only `ref:` under `with:`. Add four lines:
+
+```yaml
+jobs:
+  run:
+    runs-on: ${{ vars.CUSTOM_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          submodules: ${{ inputs.submodules }}
+          # do not persist credentials so a submodule PAT does not end up in
+          # .git/config inside the Docker build context
+          persist-credentials: false
+          # provide a token in case submodules are enabled and private (secret is expected to be present)
+          token: ${{ inputs.submodules != 'false' && secrets.GH_PAT || github.token }}
+```
+
+Three things worth understanding rather than pattern-matching:
+
+1. `persist-credentials: false` is the security hardening. Without it, `actions/checkout` writes the token into `.git/config` in the workspace — and the workspace is the Docker build context, so a `Dockerfile` with `COPY . .` and no `.dockerignore` entry for `.git` would bake the PAT into an image layer. It is safe to disable here because this workflow never pushes back via git; credentials are still used during the checkout itself.
+2. The `token:` expression falls back on purpose. When `GH_PAT` is not supplied, `secrets.GH_PAT` is the empty string, so `&&` short-circuits and `||` yields `github.token`. Submodule checkout then still works for public submodules instead of failing on an empty token.
+3. Do not "simplify" the expression to `secrets.GH_PAT || github.token`. The `inputs.submodules != 'false'` guard is what keeps the default path using `github.token`, preserving today's behaviour for every existing caller.
+
+---
+
+- [ ] **Step 7: Run actionlint to verify it passes**
+
+Run:
+
+```bash
+mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint
+```
+
+Expected: exit 0, no output. The four errors from Step 4 are gone.
+
+---
+
+- [ ] **Step 8: Run Prettier**
+
+Run:
+
+```bash
+mise x node'@24.18.1' prettier'@3.9.6' -- prettier --check .github/workflows/dockerfile.yml .github/workflows/dockerfile-build.yml .github/workflows/dockerfile-publish.yml
+```
+
+Expected: `All matched files use Prettier code style!`
+
+If it reports style issues, fix them by re-running the same command with `--write` instead of `--check`, then re-run Step 7, since reformatting can shift things.
+
+---
+
+- [ ] **Step 9: Review the diff against the constraints**
+
+Run:
+
+```bash
+git diff
+```
+
+Check each of these against the diff — they are the things most likely to be silently wrong:
+
+- `default: "false"` is quoted in all three files, and `type: string` — no booleans anywhere.
+- `GH_PAT` has no `required: true` in any file, including `dockerfile-publish.yml`.
+- The `actions/checkout` SHA is unchanged.
+- Only the three intended files appear in the diff.
+- The diff is purely additive: every hunk adds lines and removes none.
+
+---
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add .github/workflows/dockerfile.yml .github/workflows/dockerfile-build.yml .github/workflows/dockerfile-publish.yml
+git commit -m "feat(dockerfile): support submodules configuration"
+```
+
+The `hk` pre-commit hook runs Prettier and actionlint again on the staged files. It should pass, since Steps 7 and 8 already ran both. If the hook reformats anything, re-stage and re-run the commit.
+
+---
+
+## Manual verification (optional, requires a real repo)
+
+`actionlint` proves the wiring is valid but cannot prove a submodule is actually checked out. To confirm end to end, in a repo that consumes `dockerfile-build.yml` and has a private submodule:
+
+1. Set `submodules: "true"` in the caller and pass `GH_PAT: ${{ secrets.GH_PAT }}`.
+2. Run the workflow and confirm the checkout step logs the submodule clone.
+3. Confirm the Docker build sees the submodule content.
+
+This is not required to land the change — the default path is unchanged, so nothing regresses for existing callers without it.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement                                                                  | Covered by                   |
+| --------------------------------------------------------------------------------- | ---------------------------- |
+| `submodules` string input, default `"false"`, on `dockerfile.yml`                 | Step 5                       |
+| `GH_PAT` optional secret on `dockerfile.yml`, ordered after `DOCKER_HUB_PASSWORD` | Step 5                       |
+| Checkout wiring with the conditional token expression                             | Step 6                       |
+| `persist-credentials: false` hardening + rationale                                | Step 6                       |
+| Both wrappers declare and forward `submodules` and `GH_PAT`                       | Steps 2 and 3                |
+| `GH_PAT` stays optional in `dockerfile-publish.yml`                               | Step 3, re-checked in Step 9 |
+| Out-of-scope workflows untouched                                                  | Global Constraints, Step 9   |
+| Verification via hk / Prettier / actionlint                                       | Steps 1, 4, 7, 8, 10         |
+| Single `feat:` commit                                                             | Step 10                      |
+
+No gaps.
+
+**Placeholder scan:** No TBD/TODO items, no "add error handling", no "similar to Task N". Every code step contains the literal YAML to write, and every command step contains the literal command and its expected output.
+
+**Type consistency:** `submodules` (string) and `GH_PAT` (secret) are spelled identically across all three files and all steps. The token expression `${{ inputs.submodules != 'false' && secrets.GH_PAT || github.token }}` appears once, in Step 6, and matches `gradle-service.yml:109` and `mise.yml:117` character for character.
+
+**Note on the spec's verification section:** the spec left open whether actionlint runs as part of the hook set. It does — it is a core step in `wetransform/hk-config` covering `.github/workflows/*.yml`, excluding `tf-*`. This plan resolves that open question and uses actionlint as the primary test.

--- a/docs/superpowers/plans/2026-08-13-dockerfile-workflow-submodules.md
+++ b/docs/superpowers/plans/2026-08-13-dockerfile-workflow-submodules.md
@@ -233,7 +233,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref }}
           submodules: ${{ inputs.submodules }}
-          # do not persist credentials so a submodule PAT does not end up in
+          # so no checkout credential (PAT or GITHUB_TOKEN) ends up in
           # .git/config inside the Docker build context
           persist-credentials: false
           # provide a token in case submodules are enabled and private (secret is expected to be present)

--- a/docs/superpowers/plans/2026-08-13-dockerfile-workflow-submodules.md
+++ b/docs/superpowers/plans/2026-08-13-dockerfile-workflow-submodules.md
@@ -1,10 +1,12 @@
 # Dockerfile Workflow Submodules Support — Implementation Plan
 
+> **Status:** Executed. Completed in commit `3cdd187` (`feat(dockerfile): support submodules configuration`).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Let callers of the Dockerfile reusable workflows check out git submodules, including private ones, by adding a `submodules` input and an optional `GH_PAT` secret.
 
-**Architecture:** Copy the pattern already used by `gradle-library.yml`, `gradle-service.yml` and `mise.yml` verbatim: a string `submodules` input forwarded to `actions/checkout`, plus a conditional `token:` expression that swaps in `GH_PAT` only when submodules are enabled. The two wrapper workflows declare the same input and secret and pass them straight through. One extra hardening line, `persist-credentials: false`, keeps the PAT out of the Docker build context.
+**Architecture:** Copy the pattern already used by `gradle-library.yml`, `gradle-service.yml` and `mise.yml` verbatim: a string `submodules` input forwarded to `actions/checkout`, plus a conditional `token:` expression that swaps in `GH_PAT` only when submodules are enabled. The two wrapper workflows declare the same input and secret and pass them straight through. `dockerfile.yml` also sets `persist-credentials: false`, so the PAT (or default `GITHUB_TOKEN`) stays out of the Docker build context; `gradle-library.yml` and `gradle-service.yml` already carry that same setting, but for an unrelated reason (it clashes with the semantic-release action), and `mise.yml` remains the outlier that still lacks it.
 
 **Tech Stack:** GitHub Actions reusable workflows (YAML), `actions/checkout` v7, validated by `actionlint` 1.7.12 and Prettier 3.9.6, both run via the repo's `hk` pre-commit hook.
 
@@ -12,7 +14,7 @@
 
 ## Global Constraints
 
-- The `submodules` input is **type `string`**, default the quoted string `"false"` — not a boolean. The `!= 'false'` comparison in the token expression depends on this.
+- The `submodules` input is **type `string`**, default the quoted string `"false"` — not a boolean. A boolean would lose the `"recursive"` option that string inputs support, and would diverge from every other workflow in this repository, which all use a string.
 - `GH_PAT` is **always optional** — never add `required: true` to it, in any of the three files. `dockerfile-publish.yml` marks its other secrets required; `GH_PAT` must not follow suit.
 - Do **not** change the pinned `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` SHA or any other action pin.
 - Comment lines are copied verbatim from the snippets below, including the `# see https://github.com/actions/checkout` line above the input.
@@ -64,7 +66,7 @@ The exact commands and their expected output below were verified against a scrat
 
 ---
 
-- [ ] **Step 1: Confirm the starting point is green**
+- [x] **Step 1: Confirm the starting point is green**
 
 Run:
 
@@ -76,7 +78,7 @@ Expected: exit 0, no output. If there are pre-existing errors in unrelated workf
 
 ---
 
-- [ ] **Step 2: Write the failing test — declare and forward in `dockerfile-build.yml`**
+- [x] **Step 2: Write the failing test — declare and forward in `dockerfile-build.yml`**
 
 Edit `.github/workflows/dockerfile-build.yml`. Declare the input and the secret:
 
@@ -121,7 +123,7 @@ Leave the existing `# secrets: inherit` comment block above `secrets:` in place.
 
 ---
 
-- [ ] **Step 3: Write the failing test — declare and forward in `dockerfile-publish.yml`**
+- [x] **Step 3: Write the failing test — declare and forward in `dockerfile-publish.yml`**
 
 Edit `.github/workflows/dockerfile-publish.yml`. This file marks its secrets `required: true`; `GH_PAT` does **not** get that, and it sits between `DOCKER_HUB_PASSWORD` and `SLACK_NOTIFICATIONS_BOT_TOKEN`:
 
@@ -169,7 +171,7 @@ jobs:
 
 ---
 
-- [ ] **Step 4: Run actionlint to verify it fails**
+- [x] **Step 4: Run actionlint to verify it fails**
 
 Run:
 
@@ -192,7 +194,7 @@ If you instead see errors of the form `property "submodules" is not defined in o
 
 ---
 
-- [ ] **Step 5: Implement — declare the input and secret in `dockerfile.yml`**
+- [x] **Step 5: Implement — declare the input and secret in `dockerfile.yml`**
 
 Edit `.github/workflows/dockerfile.yml`. Add `submodules` after `checkout-ref`, and `GH_PAT` between `DOCKER_HUB_PASSWORD` and `SLACK_NOTIFICATIONS_BOT_TOKEN` — the same ordering `mise.yml` uses:
 
@@ -218,7 +220,7 @@ on:
 
 ---
 
-- [ ] **Step 6: Implement — wire the checkout step in `dockerfile.yml`**
+- [x] **Step 6: Implement — wire the checkout step in `dockerfile.yml`**
 
 The checkout step is the first step of the `run` job and currently has only `ref:` under `with:`. Add four lines:
 
@@ -246,7 +248,7 @@ Three things worth understanding rather than pattern-matching:
 
 ---
 
-- [ ] **Step 7: Run actionlint to verify it passes**
+- [x] **Step 7: Run actionlint to verify it passes**
 
 Run:
 
@@ -258,7 +260,7 @@ Expected: exit 0, no output. The four errors from Step 4 are gone.
 
 ---
 
-- [ ] **Step 8: Run Prettier**
+- [x] **Step 8: Run Prettier**
 
 Run:
 
@@ -272,7 +274,7 @@ If it reports style issues, fix them by re-running the same command with `--writ
 
 ---
 
-- [ ] **Step 9: Review the diff against the constraints**
+- [x] **Step 9: Review the diff against the constraints**
 
 Run:
 
@@ -290,7 +292,7 @@ Check each of these against the diff — they are the things most likely to be s
 
 ---
 
-- [ ] **Step 10: Commit**
+- [x] **Step 10: Commit**
 
 ```bash
 git add .github/workflows/dockerfile.yml .github/workflows/dockerfile-build.yml .github/workflows/dockerfile-publish.yml

--- a/docs/superpowers/specs/2026-08-13-dockerfile-workflow-submodules-design.md
+++ b/docs/superpowers/specs/2026-08-13-dockerfile-workflow-submodules-design.md
@@ -18,6 +18,11 @@ Three files:
 The other workflows that lack submodules support (`play-service.*`, `sbt-library.*`,
 `mise-release.yml`, `scan-for-secrets.yml`) are deliberately out of scope for this change.
 
+`mise.yml` already has the `submodules`/`GH_PAT` pattern but does not set
+`persist-credentials: false`. It builds Docker images from the checked-out workspace, so
+the same PAT-in-build-context exposure this spec argues against is live there today.
+Fixing that is a follow-up and is deliberately out of scope for this change.
+
 ## Approach
 
 Mirror the pattern already used by `gradle-library.yml`, `gradle-service.yml` and
@@ -85,7 +90,11 @@ an empty token.
 ### `persist-credentials: false`
 
 This line is new relative to the current `dockerfile.yml`, which leaves the setting at its
-default of `true`.
+default of `true`. It is not a new idea in this repository, though: `gradle-library.yml`
+and `gradle-service.yml` already set `persist-credentials: false`, for an unrelated reason
+— it clashes with the semantic-release action's git operations. `dockerfile.yml` sets it
+for the Docker-build-context reason below. `mise.yml` is the outlier that still lacks it,
+despite already forwarding a `GH_PAT` for submodules; see Scope.
 
 Once a `GH_PAT` is passed to `actions/checkout`, the default behaviour writes that token
 into `.git/config` in the workspace. The workspace is also the Docker build context, so a
@@ -127,14 +136,21 @@ credentials are no longer left in the workspace after checkout. Nothing in `dock
 runs git afterwards, so this affects only what a build could theoretically read out of
 `.git/config`.
 
+That said, this covers only the workflow itself, not a consumer's `Dockerfile`. If a
+caller's `Dockerfile` currently relies on the persisted `.git/config` credential to run
+`git fetch` or `git submodule` commands during the build, that build will now fail. This
+break is desirable — it is exactly the credential exposure this change closes — but it is
+a real, undocumented-until-now behaviour change, and it ships under a minor version bump.
+
 ## Verification
 
 This repository has no test harness for its workflows. Verification is:
 
 1. Run the repository's git hooks over the changed files: `mise x -- hk run pre-commit`.
    This runs Prettier, which reformats and validates the YAML.
-2. Inspect the hook output to see whether an `actionlint` step ran on the three workflows.
-   If it did not, run `actionlint` on them directly.
+2. `actionlint` is a core step in `wetransform/hk-config`, so it also runs as part of that
+   hook. Its glob covers `.github/workflows/*.yml` and excludes only `tf-*`, so it checks
+   all three changed workflows.
 3. Confirm the token expression by inspection against `gradle-service.yml` and `mise.yml`,
    from which it is copied verbatim.
 

--- a/docs/superpowers/specs/2026-08-13-dockerfile-workflow-submodules-design.md
+++ b/docs/superpowers/specs/2026-08-13-dockerfile-workflow-submodules-design.md
@@ -1,0 +1,144 @@
+# Submodules support for the Dockerfile workflows
+
+## Problem
+
+The Gradle and mise workflow families accept a `submodules` input that is forwarded to
+`actions/checkout`, together with an optional `GH_PAT` secret used to read private
+submodule repositories. The Dockerfile workflows check out code but expose neither, so a
+repository whose Docker build needs content from a submodule cannot use them.
+
+## Scope
+
+Three files:
+
+- `.github/workflows/dockerfile.yml` — the reusable workflow that performs the checkout
+- `.github/workflows/dockerfile-build.yml` — wrapper, builds without pushing
+- `.github/workflows/dockerfile-publish.yml` — wrapper, builds and pushes
+
+The other workflows that lack submodules support (`play-service.*`, `sbt-library.*`,
+`mise-release.yml`, `scan-for-secrets.yml`) are deliberately out of scope for this change.
+
+## Approach
+
+Mirror the pattern already used by `gradle-library.yml`, `gradle-service.yml` and
+`mise.yml` verbatim, rather than inventing a new one. The expression is proven in
+production and consistency across the workflow families is worth more than any marginal
+improvement.
+
+Two approaches were rejected:
+
+- **`submodules` input without `GH_PAT`.** `github.token` cannot read other private
+  repositories, so this would only work for public submodules. wetransform submodules are
+  typically private, so the feature would mostly not work.
+- **Boolean input instead of string.** Cleaner typing, but it loses `recursive` and
+  diverges from every other workflow in this repository.
+
+## Design
+
+### `dockerfile.yml`
+
+Add the input under `on.workflow_call.inputs`, after `checkout-ref`, and the secret under
+`on.workflow_call.secrets` between `DOCKER_HUB_PASSWORD` and
+`SLACK_NOTIFICATIONS_BOT_TOKEN` — the same ordering as `mise.yml`:
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      # ... existing inputs, ending with checkout-ref
+      submodules:
+        # see https://github.com/actions/checkout
+        default: "false"
+        type: string
+    secrets:
+      DOCKER_HUB_USERNAME:
+      DOCKER_HUB_PASSWORD:
+      GH_PAT:
+      SLACK_NOTIFICATIONS_BOT_TOKEN:
+```
+
+Extend the existing checkout step in the `run` job:
+
+```yaml
+jobs:
+  run:
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          submodules: ${{ inputs.submodules }}
+          # do not persist credentials so a submodule PAT does not end up in
+          # .git/config inside the Docker build context
+          persist-credentials: false
+          # provide a token in case submodules are enabled and private (secret is expected to be present)
+          token: ${{ inputs.submodules != 'false' && secrets.GH_PAT || github.token }}
+```
+
+The input is a string rather than a boolean so that `"recursive"` remains available and so
+that the `!= 'false'` comparison behaves as in the other workflows.
+
+`GH_PAT` is optional. When a caller sets `submodules` but omits the secret,
+`secrets.GH_PAT` is the empty string, the `&&` short-circuits, and `||` falls back to
+`github.token`. The workflow then still works for public submodules instead of failing on
+an empty token.
+
+### `persist-credentials: false`
+
+This line is new relative to the current `dockerfile.yml`, which leaves the setting at its
+default of `true`.
+
+Once a `GH_PAT` is passed to `actions/checkout`, the default behaviour writes that token
+into `.git/config` in the workspace. The workspace is also the Docker build context, so a
+`Dockerfile` containing `COPY . .` without a `.dockerignore` entry for `.git` would bake
+the token into an image layer. Disabling credential persistence removes that path.
+
+It is safe here because `dockerfile.yml` never pushes back via git — it builds, pushes to a
+registry, and scans. Credentials are still available during checkout itself;
+`persist-credentials` only controls what remains afterwards.
+
+### `dockerfile-build.yml` and `dockerfile-publish.yml`
+
+Both wrappers gain the same `submodules` input after `checkout-ref` and an optional
+`GH_PAT` secret, each forwarded unchanged:
+
+```yaml
+jobs:
+  build: # "publish" in dockerfile-publish.yml
+    uses: ./.github/workflows/dockerfile.yml
+    with:
+      # ... existing inputs
+      submodules: ${{ inputs.submodules }}
+    secrets:
+      # ... existing secrets
+      GH_PAT: ${{ secrets.GH_PAT }}
+```
+
+In `dockerfile-publish.yml` the existing secrets are declared `required: true`. `GH_PAT`
+stays optional, so publishing without submodules is unaffected.
+
+## Compatibility
+
+The change is additive. With `submodules` left at its default of `"false"`, the token
+expression resolves to `github.token`, which is what `actions/checkout` uses by default
+today. No existing caller needs to change.
+
+The one behavioural difference for existing callers is `persist-credentials: false`: git
+credentials are no longer left in the workspace after checkout. Nothing in `dockerfile.yml`
+runs git afterwards, so this affects only what a build could theoretically read out of
+`.git/config`.
+
+## Verification
+
+This repository has no test harness for its workflows. Verification is:
+
+1. Run the repository's git hooks over the changed files: `mise x -- hk run pre-commit`.
+   This runs Prettier, which reformats and validates the YAML.
+2. Inspect the hook output to see whether an `actionlint` step ran on the three workflows.
+   If it did not, run `actionlint` on them directly.
+3. Confirm the token expression by inspection against `gradle-service.yml` and `mise.yml`,
+   from which it is copied verbatim.
+
+## Commit
+
+A single `feat:` commit, per the repository's conventional-commits and semantic-release
+setup. Adding a workflow input is a minor version bump.

--- a/docs/superpowers/specs/2026-08-13-dockerfile-workflow-submodules-design.md
+++ b/docs/superpowers/specs/2026-08-13-dockerfile-workflow-submodules-design.md
@@ -72,7 +72,7 @@ jobs:
         with:
           ref: ${{ inputs.checkout-ref }}
           submodules: ${{ inputs.submodules }}
-          # do not persist credentials so a submodule PAT does not end up in
+          # so no checkout credential (PAT or GITHUB_TOKEN) ends up in
           # .git/config inside the Docker build context
           persist-credentials: false
           # provide a token in case submodules are enabled and private (secret is expected to be present)


### PR DESCRIPTION
Adds submodules support to the Dockerfile reusable workflows, matching the pattern the Gradle and mise families already use.

## What changed

`dockerfile.yml`, `dockerfile-build.yml` and `dockerfile-publish.yml` each gain:

- a `submodules` input (string, default `"false"`, forwarded to `actions/checkout`)
- an optional `GH_PAT` secret for reading private submodules

In `dockerfile.yml` the checkout step becomes:

```yaml
submodules: ${{ inputs.submodules }}
# so no checkout credential (PAT or GITHUB_TOKEN) ends up in
# .git/config inside the Docker build context
persist-credentials: false
token: ${{ inputs.submodules != 'false' && secrets.GH_PAT || github.token }}
```

The token expression is copied character-for-character from `gradle-service.yml` and `mise.yml`.

## `persist-credentials: false`

This is the one addition beyond a straight port. `actions/checkout` otherwise writes the credential into `.git/config` in the workspace — and the workspace *is* the Docker build context, so a `Dockerfile` with `COPY . .` and no `.dockerignore` entry for `.git` bakes it into an image layer.

It does not break submodule checkout: in checkout v7, submodule fetching is authenticated through a temporary global gitconfig set up *before* `git submodule update`, while local credential persistence is gated *after* the fetch. Safe here regardless, since this workflow never pushes back via git.

Note this also removes the default `GITHUB_TOKEN` from the build context for existing callers, not only PATs for submodule users.

## Backward compatibility

Additive. With `submodules` at its default, the token expression resolves to `github.token` — exactly what checkout uses today. No existing caller needs to change.

One behaviour change applies to all callers: git credentials are no longer left in the workspace after checkout. Nothing in `dockerfile.yml` runs git afterwards, but a consumer `Dockerfile` that relied on the persisted credential to run `git` *during the build* would now fail. That break is the exposure being closed.

If `submodules` is enabled but `GH_PAT` is not supplied, the expression falls back to `github.token` rather than passing an empty token — so it degrades to "works for public submodules".

## Verification

`actionlint` validates that each wrapper's `with:`/`secrets:` entries match the inputs and secrets declared by the reusable workflow it calls, which makes it a real test of this change. It was used as such: the wrappers were edited first and produced four contract errors, which cleared once `dockerfile.yml` declared the input and secret.

- `actionlint` — exit 0 across all workflows
- `prettier --check` — clean on all changed files

Not covered: no runtime test that a *private* submodule actually clones under `persist-credentials: false`. Worth confirming on the first adopting repo.

## Follow-up (not in this PR)

`mise.yml` forwards a `GH_PAT` for submodules and builds Docker images from the workspace via `docker/bake-action`, but does not set `persist-credentials: false` — the same exposure this PR closes is live there today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
